### PR TITLE
feat: 增加支持将Bot的回复写入历史记录

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,16 +43,19 @@
 
 - prompt: 追加到 默认 prompt 后的内容
 - limit: bot 产生回复前发送的历史记录条数
+- self_name: 历史记录中自身的称呼（回复语句），为空则使用 bot 的 id
 
 ```json
 {
   "991250350(替换为你的群号)":{
     "limit": 20,
-    "propmt": "## Group Chatting Context\n 你现在正在一个三人小群里水群."
+    "propmt": "## Group Chatting Context\n 你现在正在一个三人小群里水群.",
+    "self_name": "你"
   },
   "default":{
     "limit": 20,
-    "propmt": "you are now in a group chatting."
+    "propmt": "you are now in a group chatting.",
+    "self_name": "你"
   }
 }
 ```

--- a/config.json
+++ b/config.json
@@ -5,6 +5,7 @@
   },
   "default":{
     "limit": 20,
-    "propmt": "you are now in a group chatting."
+    "propmt": "you are now in a group chatting.",
+    "self_name": "你"
   }
 }

--- a/config.json
+++ b/config.json
@@ -1,7 +1,8 @@
 {
   "991250350":{
     "limit": 20,
-    "propmt": "## Group Chatting Context\n 你现在正在一个三人小群里水群."
+    "propmt": "## Group Chatting Context\n 你现在正在一个三人小群里水群.",
+    "self_name": "你"
   },
   "default":{
     "limit": 20,

--- a/config.py
+++ b/config.py
@@ -7,6 +7,8 @@ from dataclasses import dataclass
 class RuleObject:
     limit: int
     propmt: str
+    self_name: str | None
+    """历史记录中自身的称呼（回复语句），为空则使用Bot的ID"""
 
 
 class Config:
@@ -21,11 +23,13 @@ class Config:
             return RuleObject(
                 limit=self.data[str(group_id)]["limit"],
                 propmt=self.data[str(group_id)]["propmt"],
+                self_name=self.data[str(group_id)].get("self_name"),
             )
         else:
             return RuleObject(
                 limit=self.data["default"]["limit"],
                 propmt=self.data["default"]["propmt"],
+                self_name=self.data["default"].get("self_name"),
             )
 
     def get_by_session_name(self, session_name: str) -> RuleObject:

--- a/history.py
+++ b/history.py
@@ -48,7 +48,7 @@ class HistoryMgr:
 
     def write(self, session_name: str, query: Query, is_response: bool = False) -> None:
         """写入指定 session 历史记录"""
-        sender_id = query.sender_id if not is_response else query.adapter.bot_account_id
+        sender_id = query.sender_id if not is_response else (self.conf.get_by_session_name(session_name).self_name or query.adapter.bot_account_id)
         content = str(query.message_chain) if not is_response else "".join(
             map(
                 str, map(

--- a/history.py
+++ b/history.py
@@ -5,6 +5,7 @@ from collections import deque
 
 from pkg.core import app
 from pkg.core.entities import Query
+from pkg.platform.types.message import MessageChain
 from plugins.GroupChattingContext.config import Config
 
 
@@ -45,10 +46,16 @@ class HistoryMgr:
             self.ap.logger.info(f"读取历史记录失败: {str(e)}\n")
             return None
 
-    def write(self, session_name: str, query: Query) -> None:
+    def write(self, session_name: str, query: Query, is_response: bool = False) -> None:
         """写入指定 session 历史记录"""
-        sender_id = query.sender_id
-        content = str(query.message_chain)
+        sender_id = query.sender_id if not is_response else query.adapter.bot_account_id
+        content = str(query.message_chain) if not is_response else "".join(
+            map(
+                str, map(
+                    lambda x: x if isinstance(x, MessageChain) else x.get_content_platform_message_chain(), query.resp_messages
+                )
+            )
+        )
         timestamp = int(time.time())
         file_path = os.path.join(self.data_dir, f"{session_name}.csv")
 


### PR DESCRIPTION
效果

## 使用数字ID
```json
{
  "default":{
    "limit": 20,
    "propmt": "you are now in a group chatting."
  }
}
```
```
[11-14 10:13:29.608] history.py (91) - [INFO] : [GroupChattingContext] group_10xxxx68 写入新消息: ['27xxxx7850', '1763086409', '@24xxxx94 你好']


[11-14 10:13:29.619] process.py (39) - [INFO] : Processing request from group_10xxxx68 (0): 你好

[11-14 10:13:36.897] chat.py (98) - [INFO] : 对话(0)响应: assistant: 你好是的

[11-14 10:13:36.904] history.py (91) - [INFO] : [GroupChattingContext] group_10xxxx68 写入新消息: ['24xxxx94', '1763086416', '你好是的']
```
```csv
sender_id	timestamp	content
27xxxx7850	1763089338	@24xxxx94 你好
24xxxx94	1763089345	你好，是的
```

## 配置自身昵称
```json
{
  "default":{
    "limit": 20,
    "propmt": "you are now in a group chatting.",
    "self_name": "你"
  }
}
```
```
[11-14 10:13:29.608] history.py (91) - [INFO] : [GroupChattingContext] group_10xxxx68 写入新消息: ['27xxxx7850', '1763086409', '@24xxxx94 你好']


[11-14 10:13:29.619] process.py (39) - [INFO] : Processing request from group_10xxxx68 (0): 你好

[11-14 10:13:36.897] chat.py (98) - [INFO] : 对话(0)响应: assistant: 你好是的

[11-14 10:13:36.904] history.py (91) - [INFO] : [GroupChattingContext] group_10xxxx68 写入新消息: ['你', '1763086416', '你好是的']
```
```csv
sender_id	timestamp	content
27xxxx7850	1763089338	@24xxxx94 你好
你	1763089345	你好，是的
```